### PR TITLE
Fix mistake in help text for destiny action

### DIFF
--- a/modules/SW.GENESYS/help.js
+++ b/modules/SW.GENESYS/help.js
@@ -12,8 +12,8 @@ const help = (client, message, topic, prefix) => {
                  .addField(`${prefix}destiny roll`, `Rolls a force die and adds result to the destiny pool.`)
                  .addField(`${prefix}destiny l/light`, `Use light side point.`)
                  .addField(`${prefix}destiny d/dark`, `Use dark side point.`)
-                 .addField(`${prefix}destiny set #l #n`, `Sets destiny pool.`)
-                 .addField(`${prefix}destiny set llnn`, `Sets destiny pool`)
+                 .addField(`${prefix}destiny set #l #d`, `Sets destiny pool.`)
+                 .addField(`${prefix}destiny set lldd`, `Sets destiny pool`)
                  .addField(`${prefix}destiny reset`, `Resets the destiny pool`);
             break;
         case 'story':


### PR DESCRIPTION
The character for the `!destiny` command is [`d` not `n`](https://github.com/SkyJedi/FFGNDS-Discord-Dice-Roller/blob/98b230930faf70a47cd4a39ee5cd55611ee88e0a/modules/SW.GENESYS/destiny.js#L39-L40).